### PR TITLE
Fix AREngine session starting paused.

### DIFF
--- a/app/src/arengine/java/org/example/viotester/arengine/AREngineActivity.java
+++ b/app/src/arengine/java/org/example/viotester/arengine/AREngineActivity.java
@@ -214,6 +214,7 @@ public class AREngineActivity extends AlgorithmActivity implements GLSurfaceView
                     }
 
                     mSession.configure(config);
+                    mSession.resume();
                 } else {
                     throw new RuntimeException("This device does not support Huawei AR Engine");
                 }


### PR DESCRIPTION
Without this the camera preview doesn't work and I get on every frame:

```
2020-06-23 17:11:40.067 14959-15121/org.example.viotester D/hiar_helper: [throwExceptionJNIArStatus:36]:throwExceptionJNIArStatus ok! exceptionCode=-3
2020-06-23 17:11:40.067 14959-15121/org.example.viotester E/org.example.viotester.arengine.AREngineActivity: Exception on the OpenGL thread
    com.huawei.hiar.exceptions.ARSessionPausedException
        at com.huawei.hiar.ARServiceProxy.throwExceptionFromArStatus(ARServiceProxy.java:287)
        at com.huawei.hiar.ARSession.nativeUpdate(Native Method)
        at com.huawei.hiar.ARSession.update(ARSession.java:329)
        at org.example.viotester.arengine.AREngineActivity.onDrawFrame(AREngineActivity.java:81)
        at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1582)
        at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1281)
```