### PR TITLE
Set Camera2 parameters more suitable for recording.

### DIFF
--- a/app/src/main/java/org/example/viotester/CameraWorker.java
+++ b/app/src/main/java/org/example/viotester/CameraWorker.java
@@ -364,11 +364,11 @@ public class CameraWorker {
                         // When the session is ready, we start displaying the preview.
                         mCaptureSession = cameraCaptureSession;
                         try {
-                            CaptureRequest.Builder previewRequest = mCameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+                            CaptureRequest.Builder previewRequest = mCameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_RECORD);
                             for (Surface target : targets) {
                                 previewRequest.addTarget(target);
                             }
-                            previewRequest.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
+                            previewRequest.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO);
                             mCaptureSession.setRepeatingRequest(previewRequest.build(), mCaptureCallback, mNativeHandler);
                         } catch (CameraAccessException e) {
                             throw new RuntimeException(e);


### PR DESCRIPTION
* `TEMPLATE_RECORD` increases recording FPS from 25 to 30 on my device.
* According to the [docs](https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#CONTROL_AF_MODE_CONTINUOUS_VIDEO) `CONTROL_AF_MODE_CONTINUOUS_VIDEO` is more suitable for recordings (it's also the default with `RECORD` template).

There are other relevant looking settings such as [this one](https://developer.android.com/reference/android/hardware/camera2/CaptureRequest#CONTROL_CAPTURE_INTENT), but I'm not done investigating them.