### PR TITLE
Refactoring: Simplify mutex locks & reorganize native code

### DIFF
--- a/app/src/main/java/org/example/viotester/AlgorithmWorker.java
+++ b/app/src/main/java/org/example/viotester/AlgorithmWorker.java
@@ -313,7 +313,8 @@ public class AlgorithmWorker implements SensorEventListener, CameraWorker.Listen
         mSettings.principalPointX = mCameraParameters.principalPointX;
         mSettings.principalPointY = mCameraParameters.principalPointY;
 
-        configure(width, height, textureId, mSettings.halfFps ? 2 : 1, false, mSettings.moduleName, jsonSettings());
+        long t0 = SystemClock.elapsedRealtimeNanos(); // this should be same as the sensor clock
+        configure(t0, width, height, textureId, mSettings.halfFps ? 2 : 1, false, mSettings.moduleName, jsonSettings());
 
         if (mSettings.parametersFileName != null) {
             writeParamsFile();
@@ -402,7 +403,7 @@ public class AlgorithmWorker implements SensorEventListener, CameraWorker.Listen
     public void logExternalImage(int textureId, long timeNanos, long frameNumber, int cameraInd,
                                         int width, int height, float focalLength, float ppx, float ppy) {
         if (!mExternalInitialized) {
-            configure(width, height, textureId, 1, mSettings.recordPoses, mSettings.moduleName, jsonSettings());
+            configure(timeNanos, width, height, textureId, 1, mSettings.recordPoses, mSettings.moduleName, jsonSettings());
             configureVisualization(mScreenWidth, mScreenHeight);
             mExternalInitialized = true;
         }
@@ -410,11 +411,10 @@ public class AlgorithmWorker implements SensorEventListener, CameraWorker.Listen
         processExternalImage(timeNanos, frameNumber, cameraInd, focalLength, ppx, ppy);
     }
 
-
     public native void processExternalImage(long timeNanos, long frameNumber, int cameraInd, float focalLength, float ppx, float ppy);
 
     private native void configureVisualization(int width, int height);
-    private native void configure(int width, int height, int textureId, int frameStride, boolean recordExternalPoses, String moduleName, String settingsJson);
+    private native void configure(long timeNanos, int width, int height, int textureId, int frameStride, boolean recordExternalPoses, String moduleName, String settingsJson);
     private native boolean processFrame(long timeNanos, int cameraInd, float focalLength, float px, float py);
 
     private native void drawVisualization();

--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(${target} SHARED
         camera_worker.cpp
         algorithm_worker.cpp
         algorithm_module.cpp
+        algorithm_module_wrappers.cpp
         native_camera_session.cpp
         modules/camera_calibrator.cpp
         modules/recorder.cpp

--- a/app/src/main/jni/algorithm_module.cpp
+++ b/app/src/main/jni/algorithm_module.cpp
@@ -4,20 +4,20 @@
 using AlgoPtr = std::unique_ptr<AlgorithmModule>;
 using json = AlgorithmModule::json;
 
-AlgoPtr buildRecorder(int w, int h, const json &settings);
-AlgoPtr buildCameraCalibrator(int w, int h);
+AlgoPtr buildRecorder(int textureId, int w, int h, const json &settings);
+AlgoPtr buildCameraCalibrator(int textureId, int w, int h);
 #ifdef USE_CUSTOM_VIO
-AlgoPtr buildTracking(int w, int h, const json &settings);
+AlgoPtr buildTracking(int textureId, int w, int h, const json &settings);
 #endif
 
-AlgoPtr AlgorithmModule::build(int width, int height, const std::string &name, const json *settings) {
+AlgoPtr AlgorithmModule::build(int textureId, int width, int height, const std::string &name, const json *settings) {
     if (name == "calibration") {
-        return buildCameraCalibrator(width, height);
+        return buildCameraCalibrator(textureId, width, height);
     } else if (name == "recording" || name == "external") {
-        return buildRecorder(width, height, *settings);
+        return buildRecorder(textureId, width, height, *settings);
     } else if (name == "tracking") {
 #ifdef USE_CUSTOM_VIO
-        return buildTracking(width, height, *settings);
+        return buildTracking(textureId, width, height, *settings);
 #else
         assert(false && "custom VIO not built");
 #endif

--- a/app/src/main/jni/algorithm_module.hpp
+++ b/app/src/main/jni/algorithm_module.hpp
@@ -21,34 +21,55 @@ public:
         float accuracy;
     };
 
+    // these methods and c/dtors are guaranteed to be called from an "algorithm thread"
+    static std::unique_ptr<AlgorithmModule> build(int textureId, int width, int height, const std::string &name, const json *settings = nullptr);
+
+    virtual ~AlgorithmModule() = default;
+
     virtual void addGyro(double t, const Vector3d &val) = 0;
     virtual void addAcc(double t, const Vector3d &val) = 0;
-    virtual Pose addFrame(double t, const cv::Mat &grayFrame, cv::Mat *colorFrame,
-                          int cameraInd, double focalLength, double px, double py) = 0;
-    virtual void addGps(double t, const Gps &gps) {};
-    virtual void addJsonData(const json &json) {};
+    virtual void addGps(double t, const Gps &gps) { (void)t; (void)gps; };
+    virtual void addJsonData(const json &json) { (void)json; };
+    virtual std::string status() const { return ""; }
+    virtual int trackingStatus() { return -1; };
+
+    // these methods are called from the OpenGL thread
+    virtual void addFrame(double t, int cameraInd, double focalLength, double px, double py) = 0;
 
     /**
      * If this module supports visualizations, initialize visualizations for
      * given screen size
      * @param width screen / visualization window width
      * @param height screen / visualization window height
-     * @return true if visualizations are supported, false otherwise
      */
-    virtual bool setupRendering(int width, int height) { (void)width; (void)height; return false; }
+    virtual void setupRendering(int width, int height) { (void)width; (void)height; }
 
-    /**
-     * @param outMat MUST be CV_8UC4, and the same size (or the same object) as created by
-     *  setupRendering, which must be called first
-     * @return true if something was rendered. false otherwise
-     */
+    /** Render visualizations, if any */
     virtual void render() {}
-    virtual std::string status() const { return ""; }
-    virtual int trackingStatus() { return -1; };
 
-    virtual ~AlgorithmModule() = default;
+    // This helper function will protect all calls with a single mutex
+    static std::unique_ptr<AlgorithmModule> makeThreadSafe(AlgorithmModule *nonThreadSafe);
+};
 
-    static std::unique_ptr<AlgorithmModule> build(int width, int height, const std::string &name, const json *settings = nullptr);
+class CpuAlgorithmModule : public AlgorithmModule {
+public:
+    virtual void addFrame(double t, const cv::Mat &grayFrame, cv::Mat *colorFrame,
+                          int cameraInd, double focalLength, double px, double py,
+                          cv::Mat &outputColorFrame) = 0;
+
+    void addFrame(double t, int cameraInd, double focalLength, double px, double py) final;
+    void setupRendering(int width, int height) final;
+    void render() final;
+
+    virtual ~CpuAlgorithmModule();
+
+protected:
+    CpuAlgorithmModule(int textureId, int width, int height);
+    bool visualizationEnabled = true;
+
+private:
+    struct impl;
+    std::unique_ptr<impl> pimpl;
 };
 
 #endif

--- a/app/src/main/jni/algorithm_module_wrappers.cpp
+++ b/app/src/main/jni/algorithm_module_wrappers.cpp
@@ -1,0 +1,140 @@
+#include <cassert>
+#include <opencv2/core.hpp>
+
+#include "opengl/gpu_camera_adapter.hpp"
+#include "opengl/camera_renderer.hpp"
+#include "algorithm_module.hpp"
+#include "logging.hpp"
+
+struct CpuAlgorithmModule::impl {
+    cv::Mat colorFrame, grayFrame, visualization;
+    std::mutex mutex, renderMutex;
+    std::unique_ptr<GpuCameraAdapter> gpuAdapter;
+    std::unique_ptr<GpuCameraAdapter::TextureAdapter> rgbaTexture, grayTexture;
+    std::unique_ptr<CameraRenderer> renderer;
+};
+
+CpuAlgorithmModule::~CpuAlgorithmModule() = default;
+
+CpuAlgorithmModule::CpuAlgorithmModule(int textureId, int width, int height) : pimpl(new impl) {
+    log_debug("setting up CPU frames %d x %d (tex ID %d)", width, height, textureId);
+    pimpl->colorFrame = cv::Mat(cv::Size(width, height), CV_8UC4);
+    pimpl->grayFrame = cv::Mat(cv::Size(width, height), CV_8UC1);
+
+    pimpl->gpuAdapter = GpuCameraAdapter::create(width, height, textureId);
+    pimpl->grayTexture = pimpl->gpuAdapter->createTextureAdapter(
+            GpuCameraAdapter::TextureAdapter::Type::GRAY_COMPRESSED);
+}
+
+void CpuAlgorithmModule::setupRendering(int visuWidth, int visuHeight) {
+    if (visualizationEnabled) {
+        std::lock_guard<std::mutex> lock(pimpl->mutex);
+        pimpl->rgbaTexture = pimpl->gpuAdapter->createTextureAdapter(GpuCameraAdapter::TextureAdapter::Type::BGRA);
+        log_debug("screen size size set to %dx%d", visuWidth, visuHeight);
+        pimpl->renderer = CameraRenderer::build(visuWidth, visuHeight);
+    }
+}
+
+void CpuAlgorithmModule::addFrame(double t, int cameraInd, double focalLength, double px, double py) {
+    std::lock_guard<std::mutex> lock(pimpl->mutex);
+    pimpl->grayTexture->render();
+    pimpl->grayTexture->readPixels(pimpl->grayFrame.data);
+
+    if (pimpl->rgbaTexture) {
+        assert(!pimpl->colorFrame.empty());
+        pimpl->rgbaTexture->render();
+        pimpl->rgbaTexture->readPixels(pimpl->colorFrame.data);
+    }
+
+    addFrame(t, pimpl->grayFrame, visualizationEnabled ? &pimpl->colorFrame : nullptr,
+             cameraInd, focalLength, px, py, pimpl->visualization);
+
+    if (visualizationEnabled) {
+        assert(pimpl->renderer);
+        std::lock_guard<std::mutex> lock(pimpl->renderMutex);
+        pimpl->renderer->setTextureData(pimpl->visualization.cols, pimpl->visualization.rows,
+                pimpl->visualization.data, CameraRenderer::AspectFixMethod::CROP);
+    }
+}
+
+void CpuAlgorithmModule::render() {
+    if (!visualizationEnabled) return;
+    std::lock_guard<std::mutex> lock(pimpl->renderMutex);
+    pimpl->renderer->render();
+}
+
+class MutexLockedImplementation : public AlgorithmModule {
+public:
+    typedef std::lock_guard<std::mutex> Lock;
+    void addGyro(double t, const Vector3d &val) final {
+        Lock lock(m);
+        p->addGyro(t, val);
+    }
+
+    void addAcc(double t, const Vector3d &val) final {
+        Lock lock(m);
+        p->addAcc(t, val);
+    }
+
+    void addGps(double t, const Gps &gps) final {
+        Lock lock(m);
+        p->addGps(t, gps);
+    }
+
+    void addJsonData(const json &json) final {
+        Lock lock(m);
+        p->addJsonData(json);
+    }
+
+    std::string status() const final {
+        Lock lock(const_cast<MutexLockedImplementation*>(this)->statusLock);
+        return statusStruct.textStatus;
+    }
+
+    int trackingStatus() final {
+        Lock lock(statusLock);
+        return statusStruct.trackingStatus;
+    }
+
+    void addFrame(double t, int cameraInd, double focalLength, double px, double py) final {
+        Status tmpStatus;
+        {
+            Lock lock(m);
+            p->addFrame(t, cameraInd, focalLength, px, py);
+            tmpStatus = {
+                .textStatus = p->status(),
+                .trackingStatus = p->trackingStatus()
+            };
+        }
+
+        {
+            Lock lock(statusLock);
+            statusStruct = tmpStatus;
+        }
+    }
+
+    void setupRendering(int width, int height) final {
+        Lock lock(m);
+        return p->setupRendering(width, height);
+    }
+
+    void render() final {
+        Lock lock(m);
+        p->render();
+    }
+
+    MutexLockedImplementation(AlgorithmModule *nonThreadSafe) : p(nonThreadSafe) {}
+
+private:
+    struct Status {
+        std::string textStatus = "";
+        int trackingStatus = -1;
+    } statusStruct;
+
+    std::mutex m, statusLock;
+    std::unique_ptr<AlgorithmModule> p;
+};
+
+std::unique_ptr<AlgorithmModule> AlgorithmModule::makeThreadSafe(AlgorithmModule *nonThreadSafe) {
+    return std::unique_ptr<AlgorithmModule>(new MutexLockedImplementation(nonThreadSafe));
+}

--- a/app/src/main/jni/algorithm_worker.cpp
+++ b/app/src/main/jni/algorithm_worker.cpp
@@ -1,12 +1,10 @@
 #include <jni.h>
 #include <memory>
-#include <opencv2/core.hpp>
-#include <opencv2/imgproc.hpp>
+#include <atomic>
+
 #include <Eigen/Dense>
 #include "logging.hpp"
 #include <nlohmann/json.hpp>
-#include "opengl/gpu_camera_adapter.hpp"
-#include "opengl/camera_renderer.hpp"
 #include "algorithm_module.hpp"
 #include <fstream>
 #include "jniutil.hpp"
@@ -14,38 +12,20 @@
 using nlohmann::json;
 
 namespace {
-    // auxiliary stuff for visualizations and preprocessing
-    int width;
-    int height;
-    cv::Mat colorFrame, grayFrame;
-
-    struct PendingFrame {
-        bool pending = false;
-        long timeNanos;
-        cv::Mat colorFrame, grayFrame;
-        float focalLength, ppx, ppy;
-        int cameraInd;
-    } pendingFrame;
-
     bool recordExternalPoses = false;
-    bool visualizationEnabled = false;
     int frameStride = 1;
     int frameNumber = 0;
-    std::mutex algorithmMutex, frameMutex;
-
-    std::unique_ptr<GpuCameraAdapter> gpuAdapter;
-    std::unique_ptr<GpuCameraAdapter::TextureAdapter> rgbaTexture, grayTexture;
 
     json settingsJson;
-    std::unique_ptr<AlgorithmModule> algorithm;
+    std::shared_ptr<AlgorithmModule> algorithmPtr;
+
     class Clock {
     public:
-        double update(int64_t tNanos) {
-            if (t0 == 0) t0 = tNanos;
+        double update(int64_t tNanos) const {
             return (tNanos - t0) * 1e-9 + MARGIN;
         }
 
-        Clock() : t0(0) {}
+        Clock(int64_t t = 0) : t0(t) {}
 
     private:
         /**
@@ -56,105 +36,45 @@ namespace {
         int64_t t0;
     };
 
+    // TODO: not thread-safe
     Clock doubleClock;
-
-    void renderToPendingFrame(long timeNanos, int cameraInd, float focalLength, float px, float py) {
-        std::lock_guard<std::mutex> lock(frameMutex);
-        if (!gpuAdapter || !grayTexture) {
-            log_warn("render after teardown: skipping");
-            return;
-        }
-
-        grayTexture->render();
-        grayTexture->readPixels(grayFrame.data);
-
-        if (rgbaTexture) {
-            assert(!colorFrame.empty());
-            rgbaTexture->render();
-            rgbaTexture->readPixels(colorFrame.data);
-        }
-
-        // for debugging
-        //cv::cvtColor(colorFrame, grayFrame, cv::COLOR_BGRA2GRAY);
-        //cv::cvtColor(grayFrame, colorFrame, cv::COLOR_GRAY2BGRA);
-
-        colorFrame.copyTo(pendingFrame.colorFrame);
-        grayFrame.copyTo(pendingFrame.grayFrame);
-        pendingFrame.timeNanos = timeNanos;
-        pendingFrame.focalLength = focalLength;
-        pendingFrame.ppx = px;
-        pendingFrame.ppy = py;
-        pendingFrame.pending = true;
-        pendingFrame.cameraInd = cameraInd;
-    }
-
-    void consumePendingFrame() {
-        // note: this should work fine if addFrame is a light-weight queuing operation.
-        // if not, it might make sense to copy the image data to a third buffer first
-        std::lock_guard<std::mutex> lock(frameMutex);
-        if (pendingFrame.pending) {
-            pendingFrame.pending = false;
-            algorithm->addFrame(
-                    doubleClock.update(pendingFrame.timeNanos), grayFrame, visualizationEnabled ? &colorFrame : nullptr,
-                    pendingFrame.cameraInd, pendingFrame.focalLength, pendingFrame.ppx, pendingFrame.ppy);
-        }
-    }
 }
 
 extern "C" {
 
-JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_nativeStop(
-        JNIEnv *env, jobject) {
+JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_nativeStop(JNIEnv *, jobject) {
     log_debug("nativeStop");
-    {
-        std::lock_guard<std::mutex> lock(algorithmMutex);
-        algorithm.reset();
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(frameMutex);
-        rgbaTexture.reset();
-        grayTexture.reset();
-        gpuAdapter.reset();
-        pendingFrame.pending = false;
-    }
+    std::atomic_store(&algorithmPtr, std::shared_ptr<AlgorithmModule>(nullptr));
 }
 
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_configureVisualization(
-        JNIEnv *env, jobject,
+        JNIEnv *, jobject,
         jint visuWidth, jint visuHeight) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
+    auto algorithm = std::atomic_load(&algorithmPtr);
     if (!algorithm) {
         // happens on external AR. TODO: hacky
         log_warn("no algorithm, ignoring configureVisualization");
         return;
     }
-
-    visualizationEnabled = algorithm->setupRendering(visuWidth, visuHeight);
-    if (visualizationEnabled) {
-        assert(gpuAdapter);
-        std::lock_guard<std::mutex> frameLock(frameMutex);
-        rgbaTexture = gpuAdapter->createTextureAdapter(GpuCameraAdapter::TextureAdapter::Type::BGRA);
-        log_debug("screen size size set to %dx%d", visuWidth, visuHeight);
-    }
+    log_debug("configureVisualization(%d, %d)", visuWidth, visuHeight);
+    algorithm->setupRendering(visuWidth, visuHeight);
 }
 
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_configure(
         JNIEnv *env, jobject,
-        jint widthJint,
-        jint heightJint,
+        jlong timeNanos,
+        jint width,
+        jint height,
         jint textureId,
         jint frameStrideJint,
         jboolean recordExternalPosesJboolean,
         jstring moduleNameJava,
         jstring moduleSettingsJson) {
-    {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
-    algorithm.reset();
-    doubleClock = {};
 
-    width = static_cast<int>(widthJint);
-    height = static_cast<int>(heightJint);
+    std::atomic_store(&algorithmPtr, std::shared_ptr<AlgorithmModule>(nullptr));
+    doubleClock = Clock(timeNanos);
+
+    frameNumber = 0;
     frameStride = static_cast<int>(frameStrideJint);
     recordExternalPoses = recordExternalPosesJboolean;
 
@@ -169,74 +89,66 @@ JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_configure(
         log_debug("json settings\n%s", settingsJson.dump(2).c_str());
         settingsJsonPtr = &settingsJson;
     }
-    algorithm = AlgorithmModule::build(width, height, moduleName, settingsJsonPtr);
-    }
 
-    {
-    std::lock_guard<std::mutex> lock(frameMutex);
-    gpuAdapter = GpuCameraAdapter::create(width, height, textureId);
-    grayTexture = gpuAdapter->createTextureAdapter(
-            GpuCameraAdapter::TextureAdapter::Type::GRAY_COMPRESSED);
-
-    log_debug("setting up color frames");
-    colorFrame = cv::Mat(cv::Size(width, height), CV_8UC4);
-    grayFrame = cv::Mat(cv::Size(width, height), CV_8UC1);
-    }
+    auto ptr = AlgorithmModule::build(textureId, width, height, moduleName, settingsJsonPtr);
+    std::atomic_store(&algorithmPtr, std::shared_ptr<AlgorithmModule>(std::move(ptr)));
 }
 
 JNIEXPORT jboolean JNICALL Java_org_example_viotester_AlgorithmWorker_processFrame(
-        JNIEnv *env, jobject,
+        JNIEnv *, jobject,
         jlong timeNanos,
         jint cameraInd,
         jfloat focalLength,
         jfloat px,
         jfloat py) {
+    auto algorithm = std::atomic_load(&algorithmPtr);
+    if (!algorithm) return false;
 
     if ((frameNumber++ % frameStride) != 0) return false;
 
-    renderToPendingFrame(timeNanos, cameraInd, focalLength, px, py);
+    algorithm->addFrame(doubleClock.update(timeNanos), cameraInd,focalLength, px, py);
     return true;
 }
 
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_processGyroSample(
         JNIEnv*, jobject,
         jlong timeNanos, jfloat x, jfloat y, jfloat z) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
-    if (algorithm) {
-        algorithm->addGyro(doubleClock.update(timeNanos), { x, y, z });
-        consumePendingFrame();
-    }
+    auto algorithm = std::atomic_load(&algorithmPtr);
+    if (!algorithm) return;
+
+    algorithm->addGyro(doubleClock.update(timeNanos), { x, y, z });
 }
 
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_processAccSample(
         JNIEnv*, jobject,
         jlong timeNanos, jfloat x, jfloat y, jfloat z) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
-    if (algorithm) algorithm->addAcc(doubleClock.update(timeNanos), { x, y, z });
+    auto algorithm = std::atomic_load(&algorithmPtr);
+    if (!algorithm) return;
+    algorithm->addAcc(doubleClock.update(timeNanos), { x, y, z });
 }
 
 JNIEXPORT jstring JNICALL Java_org_example_viotester_AlgorithmWorker_getStatsString(
         JNIEnv *env, jobject) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
+    auto algorithm = std::atomic_load(&algorithmPtr);
     if (algorithm) return env->NewStringUTF(algorithm->status().c_str());
     return nullptr;
 }
 
 JNIEXPORT jint JNICALL Java_org_example_viotester_AlgorithmWorker_getTrackingStatus(
-        JNIEnv *env, jobject) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
+        JNIEnv *, jobject) {
+    auto algorithm = std::atomic_load(&algorithmPtr);
     if (algorithm) return algorithm->trackingStatus();
     return -1;
 }
 
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_drawVisualization(JNIEnv *, jobject) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
+    auto algorithm = std::atomic_load(&algorithmPtr);
     if (!algorithm) return;
     algorithm->render();
 }
 
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_processGpsLocation(JNIEnv *, jobject, jlong timeNanos, jdouble lat, jdouble lon, jdouble alt, jfloat acc) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
+    auto algorithm = std::atomic_load(&algorithmPtr);
     if (!algorithm) return;
     algorithm->addGps(doubleClock.update(timeNanos), AlgorithmModule::Gps {
             .latitude = lat,
@@ -249,7 +161,7 @@ JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_processGpsLoca
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_writeInfoFile(
         JNIEnv* env, jobject,
         jstring mode, jstring device) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
+    auto algorithm = std::atomic_load(&algorithmPtr);
     if (!algorithm) return;
 
     std::string infoFile = !settingsJson.at("infoFileName").is_null() ? settingsJson.at("infoFileName") : "";
@@ -272,9 +184,6 @@ JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_writeInfoFile(
 
 JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_writeParamsFile(
         JNIEnv*, jobject) {
-    std::lock_guard<std::mutex> lock(algorithmMutex);
-    if (!algorithm) return;
-
     std::string paramsFile = !settingsJson.at("parametersFileName").is_null() ? settingsJson.at("parametersFileName") : "";
     if (paramsFile.empty())
         return;
@@ -282,18 +191,17 @@ JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_writeParamsFil
     fileOutput << "imuToCameraMatrix -0,-1,0,-1,0,0,0,0,-1;" << std::endl;
 }
 
-JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_processExternalImage(JNIEnv *env, jobject thiz,
+JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_processExternalImage(JNIEnv *, jobject,
         jlong timeNs, jlong frameNumber, jint cameraInd, jfloat focalLength, jfloat ppx, jfloat ppy) {
-    renderToPendingFrame(timeNs, cameraInd, focalLength, ppx, ppy);
+    (void)frameNumber;
+    auto algorithm = std::atomic_load(&algorithmPtr);
+    if (!algorithm) return;
+    algorithm->addFrame(doubleClock.update(timeNs), cameraInd, focalLength, ppx, ppy);
 }
 
-JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_recordPoseMatrix(JNIEnv *env, jobject thiz, jlong timeNs, jfloatArray pose, jstring tag) {
-    (void)thiz;
-    std::lock_guard<std::mutex> lock(algorithmMutex);
+JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_recordPoseMatrix(JNIEnv *env, jobject, jlong timeNs, jfloatArray pose, jstring tag) {
+    auto algorithm = std::atomic_load(&algorithmPtr);
     if (!algorithm) return;
-
-    consumePendingFrame();
-
     if (!recordExternalPoses) return;
 
     auto *poseArr = env->GetFloatArrayElements(pose, nullptr);
@@ -305,7 +213,6 @@ JNIEXPORT void JNICALL Java_org_example_viotester_AlgorithmWorker_recordPoseMatr
     const Eigen::Matrix3f R = viewMatrix.block<3, 3>(0, 0);
     const Eigen::Vector3f p = -R.transpose() * viewMatrix.block<3, 1>(0, 3);
     const Eigen::Quaternionf q(R);
-
 
     algorithm->addJsonData(
             AlgorithmModule::json {


### PR DESCRIPTION
Now the algorithm_worker is mostly JNI glue and the other parts of the implementation have somewhat cleaner responsibilities

 * give t0 for long -> double timestamp conversion in ctor, this makes the Clock object immutable and thread-safe
 * use std::atomic_load/store to make sure the algorithm object exists when accessed (not an ideal solution)
 * remove thread-safety guarantees provided by algorithm_worker
 * the thread-safety should be guaranteed either by the algorithm module...
 * or by using the makeThreadSafe helper which puts everything inside a mutex lock
 * also added a default CPU-based rendering implementation, but moved the choice whether or not to use it to the algorithm
   modules