### PR TITLE
Recorder needs color frame

### DIFF
--- a/app/src/main/jni/modules/recorder.cpp
+++ b/app/src/main/jni/modules/recorder.cpp
@@ -17,7 +17,7 @@ struct RecordingModule : public CpuAlgorithmModule {
         log_info("recording only mode");
         recordSensors = settings.at("recordSensors").get<bool>();
         recordCamera = settings.at("recordCamera").get<bool>();
-        visualizationEnabled = settings.at("previewCamera").get<bool>();
+        visualizationEnabled = settings.at("previewCamera").get<bool>() || recordCamera;
 
         auto recName = settings.at("recordingFileName");
         auto videoRecName = settings.at("videoRecordingFileName");


### PR DESCRIPTION
I'm not sure if this is the best fix for this. The color frame seems to be produced only if visualizations are enabled, but it's required by Recorder for video which crashes without.